### PR TITLE
Don't use legacy sign

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.sat7</groupId>
     <artifactId>DynamicShop</artifactId>
-    <version>2.11.8-SNAPSHOT</version>
+    <version>2.11.8</version>
     <packaging>jar</packaging>
 
     <name>DynamicShop</name>

--- a/src/main/java/me/sat7/dynamicshop/guis/Shop.java
+++ b/src/main/java/me/sat7/dynamicshop/guis/Shop.java
@@ -132,7 +132,7 @@ public class Shop {
         // 어드민이면 우클릭
         if(player.hasPermission("dshop.admin.shopedit")) infoLore.add(LangUtil.ccLang.get().getString("RMB_EDIT"));
 
-        ItemStack infoBtn =  ItemsUtil.createItemStack(Material.LEGACY_SIGN,null, "§3"+shopName, infoLore,1);
+        ItemStack infoBtn =  ItemsUtil.createItemStack(Material.OAK_SIGN,null, "§3"+shopName, infoLore,1);
         inventory.setItem(53,infoBtn);
 
         // 상품목록 등록


### PR DESCRIPTION
Gets rid of the legacy warning. Plugin only supports 1.13+ anyways.